### PR TITLE
refactor(shards)!: switch to agnostic handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs
 .env
 .yarn/cache
 .yarn/install-state.gz
+.token

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -ex
 
 if git status | grep -q "\\.ts"; then 
   if [ -x "$(command -v prettier)" ]; then

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,17 @@
 {
   "configurations": [
     {
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/test/index.js",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node",
+      "env": {
+        "NODE_ENV": "development",
+        "DISCORD_TOKEN": "::readfrom::~~/.token"
+      }
+    },
+    {
       "command": "source .env && npm start",
       "name": "Run npm start",
       "request": "launch",

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,7 +2,7 @@ nodeLinker: node-modules
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
-    spec: "@yarnpkg/plugin-typescript"
+    spec: '@yarnpkg/plugin-typescript'
 
 yarnPath: .yarn/releases/yarn-3.2.0.cjs
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuwa",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.1-beta.2",
   "description": "不和 (fuwa) is a simple, easy-to-use and lightweight Discord API wrapper",
   "main": "./dist/index.js",
   "type": "commonjs",

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -139,12 +139,15 @@ export class Client extends EventEmitter {
   public channels: ChannelManager;
 
   /**
-   * The client's public-facing user. Extended with additional information.
+   * The client's public-facing user. Extended with additional information. Null if thr
+   * client is not logged in.
    */
   public user: ExtendedUser | null = null;
 
   private timeouts: Array<NodeJS.Timeout> = [];
   private timers: Array<NodeJS.Timeout> = [];
+
+  /** @internal @ignore */ _ready = false;
 
   public constructor(token: string, options?: ClientOptions) {
     super();

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -147,8 +147,6 @@ export class Client extends EventEmitter {
   private timeouts: Array<NodeJS.Timeout> = [];
   private timers: Array<NodeJS.Timeout> = [];
 
-  /** @internal @ignore */ _ready = false;
-
   public constructor(token: string, options?: ClientOptions) {
     super();
 

--- a/src/logging/DefaultLogger.ts
+++ b/src/logging/DefaultLogger.ts
@@ -72,7 +72,9 @@ export class DefaultLogger implements ILogger {
   }
 
   public log(...data: any[]): void {
-    process.stdout.write(
+    (process.env.NODE_ENV === 'development'
+      ? console.log
+      : process.stdout.write.bind(process.stdout))(
       data
         .map(d =>
           typeof d === 'string'

--- a/src/structures/Channel.ts
+++ b/src/structures/Channel.ts
@@ -13,7 +13,10 @@ import { consumeJSON } from '../rest/RequestManager.js';
 import type { DMChannel } from './DMChannel.js';
 import { Guild } from './Guild';
 import { GuildChannel, GuildChannels } from './GuildChannel.js';
+import { GuildTextChannel } from './GuildTextChannel.js';
+import { GuildVoiceChannel } from './GuildVoiceChannel.js';
 import { BaseStructure } from './templates/BaseStructure';
+import { TextChannel } from './templates/BaseTextChannel.js';
 
 export class Channel<
   T extends APIChannel = APIChannel,
@@ -92,8 +95,38 @@ export class Channel<
     return {
       id: this.id,
       type: this.type,
-      guild_id: this.guildId,
+      guild_id: this.guildId ?? undefined,
     } as T;
+  }
+
+  //#region Typeguards
+  public isDM(): this is DMChannel {
+    return this.type === ChannelType.DM;
+  }
+  public isGuild(): this is GuildChannels {
+    return ChannelType[this.type].startsWith('Guild');
+  }
+  public isText(): this is GuildTextChannel {
+    return this.type === ChannelType.GuildText;
+  }
+  public isVoice(): this is GuildVoiceChannel {
+    return this.type === ChannelType.GuildVoice;
+  }
+  public isCategory(): this is GuildChannel {
+    return this.type === ChannelType.GuildCategory;
+  }
+  public isTextBased(): this is TextChannel {
+    return (
+      this.type === ChannelType.GuildText ||
+      this.type === ChannelType.DM ||
+      this.type === ChannelType.GuildVoice
+    );
+  }
+  public isVoiceBased(): this is GuildVoiceChannel {
+    return (
+      this.type === ChannelType.GuildVoice ||
+      this.type === ChannelType.GuildStageVoice
+    );
   }
 }
 

--- a/src/structures/GuildChannel.ts
+++ b/src/structures/GuildChannel.ts
@@ -100,7 +100,7 @@ export class GuildChannel<
       name: this.name,
       position: this.position,
       nsfw: this.nsfw,
-      parent_id: this.parentId,
+      parent_id: this.parentId ?? undefined,
     };
   }
 }

--- a/src/structures/GuildMember.ts
+++ b/src/structures/GuildMember.ts
@@ -62,7 +62,7 @@ export class GuildMember extends BaseStructure<APIGuildMember> {
   }
 
   public _deserialise(
-    data: APIGuildMember & { joined_at: string | null },
+    data: APIGuildMember & { joined_at?: string | null },
   ): this {
     if ('user' in data) {
       this.userId = data.user!.id as Snowflake;

--- a/src/structures/GuildTextChannel.ts
+++ b/src/structures/GuildTextChannel.ts
@@ -15,7 +15,7 @@ export class GuildTextChannel extends BaseGuildTextChannel {
   toJSON(): APIGuildTextChannel<ChannelType.GuildText> {
     return {
       ...super.toJSON(),
-      topic: this.topic,
+      topic: this.topic ?? undefined,
     } as any;
   }
 }

--- a/src/structures/GuildVoiceChannel.ts
+++ b/src/structures/GuildVoiceChannel.ts
@@ -23,7 +23,7 @@ export class GuildVoiceChannel extends BaseTextChannelInGuild {
     return {
       ...super.toJSON(),
       bitrate: this.bitrate ?? 0,
-      rtc_region: this.region,
+      rtc_region: this.region ?? undefined,
       user_limit: this.userLimit! ?? undefined,
       video_quality_mode: this.videoQuality,
       type: this.type as any,

--- a/src/structures/MessageEmbed.ts
+++ b/src/structures/MessageEmbed.ts
@@ -227,13 +227,13 @@ export interface EmbedVideo {
   url?: string | null;
   height?: number | null;
   width?: number | null;
-};
+}
 export interface EmbedThumbnail {
   url: string;
   height?: number | null;
   width?: number | null;
   proxyURL?: string | null;
-};
+}
 export interface EmbedAuthor {
   name: string;
   url?: string | null;

--- a/src/structures/templates/BaseTextChannel.ts
+++ b/src/structures/templates/BaseTextChannel.ts
@@ -12,6 +12,7 @@ import { Channel } from '../Channel.js';
 import { DMChannel } from '../DMChannel';
 import { GuildChannel } from '../GuildChannel';
 import { GuildTextChannel } from '../GuildTextChannel';
+import { GuildVoiceChannel } from '../GuildVoiceChannel.js';
 import { ChannelMessageManager } from '../managers/ChannelMessageManager';
 
 // i hate this so much
@@ -81,4 +82,4 @@ export const BaseTextChannel = function (
   new (client: Client): BaseTextChannel;
 };
 
-export type TextChannel = DMChannel | GuildTextChannel;
+export type TextChannel = DMChannel | GuildTextChannel | GuildVoiceChannel;

--- a/src/ws/DispatchHandler.ts
+++ b/src/ws/DispatchHandler.ts
@@ -1,12 +1,18 @@
 import {
+  APIGuildMember,
+  APIMessage,
   GatewayDispatchEvents,
   GatewayDispatchPayload,
 } from 'discord-api-types/v10';
+import { Channel } from '../structures/Channel.js';
 import { ExtendedUser } from '../structures/ExtendedUser';
 import { Guild } from '../structures/Guild';
+import { GuildChannels } from '../structures/GuildChannel.js';
+import { GuildMember } from '../structures/GuildMember.js';
+import { Message } from '../structures/Message.js';
 import { Intents } from '../util/bitfields/Intents';
 import { GatewayManager } from './GatewayManager';
-import { GatewayShard, ShardState } from './GatewayShard';
+import { GatewayShard } from './GatewayShard';
 
 export function handleDispatch(
   manager: GatewayManager,
@@ -14,6 +20,7 @@ export function handleDispatch(
   shard: GatewayShard,
 ) {
   switch (data.t) {
+    //#region Shards
     case GatewayDispatchEvents.Ready: {
       shard.session = data.d.session_id;
       shard._awaitedGuilds = data.d.guilds.map(g => g.id);
@@ -49,6 +56,9 @@ export function handleDispatch(
       shard.ready();
       break;
     }
+    //#endregion
+
+    //#region Guilds
     case GatewayDispatchEvents.GuildCreate: {
       const guild = new Guild(shard.client)._deserialise(data.d);
       shard.client.guilds.add(guild);
@@ -81,7 +91,274 @@ export function handleDispatch(
       break;
     }
     case GatewayDispatchEvents.GuildDelete: {
-      shard.client.guilds.delete(data.d.id);
+      shard.client.guilds.remove(data.d.id);
+      break;
+    }
+    //#endregion
+
+    //#region Channels
+    case GatewayDispatchEvents.ChannelCreate: {
+      const channel = Channel.create(shard.client, data.d as unknown as any);
+
+      if ((<any>data.d).guild_id) {
+        const guild = shard.client.guilds.get((<any>data.d).guild_id);
+
+        if (!guild) {
+          shard.warn(
+            `received channel create for ${data.d.id} but it doesn't exist in cache; ignoring`,
+          );
+          break;
+        }
+
+        guild.channels.add(channel as GuildChannels);
+      } else {
+        shard.client.channels.add(channel);
+      }
+
+      manager.event('channelCreate', channel);
+
+      break;
+    }
+    case GatewayDispatchEvents.ChannelUpdate: {
+      let channel = shard.client.channels.get(data.d.id);
+      const oldChannel = shard.client.channels.get(data.d.id);
+
+      if (!channel) {
+        shard.warn(
+          `received channel update for ${data.d.id} but it doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      if (data.d.type && channel.type !== data.d.type) {
+        // @ts-ignore
+        channel = Channel.create(shard.client, {
+          ...channel.toJSON(),
+          ...data.d,
+        });
+      } else {
+        channel._deserialise(data.d);
+      }
+
+      if (channel.guildId) {
+        const guild = shard.client.guilds.get(channel.guildId);
+
+        if (!guild) {
+          shard.warn(
+            `received channel update for ${data.d.id} but guild doesn't exist in cache; not setting in guild`,
+          );
+        } else {
+          guild.channels.update(channel as GuildChannels);
+        }
+      }
+
+      shard.client.channels.update(channel);
+
+      manager.event('channelUpdate', channel, oldChannel);
+      break;
+    }
+    case GatewayDispatchEvents.ChannelDelete: {
+      const channel = shard.client.channels.get(data.d.id);
+
+      if (!channel) break;
+
+      if (channel.guildId) {
+        const guild = shard.client.guilds.get(channel.guildId);
+
+        if (!guild) {
+          shard.warn(
+            `received channel delete for ${data.d.id} but guild doesn't exist in cache; not removing from guild`,
+          );
+        } else {
+          guild.channels.remove(channel.id);
+        }
+      }
+
+      shard.client.channels.remove(channel.id);
+
+      manager.event('channelDelete', channel);
+      break;
+    }
+    //#endregion
+
+    //#region Members
+    case GatewayDispatchEvents.GuildMemberAdd: {
+      const guild = shard.client.guilds.get(data.d.guild_id);
+
+      if (!guild) {
+        shard.warn(
+          `received member add for ${data.d.guild_id} but guild doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      const member = new GuildMember(shard.client, guild.id)._deserialise(
+        data.d,
+      );
+
+      guild.members.add(member);
+
+      manager.event('guildMemberAdd', member);
+      break;
+    }
+    case GatewayDispatchEvents.GuildMemberUpdate: {
+      const guild = shard.client.guilds.get(data.d.guild_id);
+
+      if (!guild) {
+        shard.warn(
+          `received member update for ${data.d.guild_id} but guild doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      const member = guild.members.get(data.d.user.id);
+
+      if (!member) {
+        shard.warn(
+          `received member update for ${data.d.user.id} but member doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      member._deserialise(data.d as APIGuildMember);
+
+      guild.members.update(member);
+
+      manager.event('guildMemberUpdate', member);
+      break;
+    }
+    case GatewayDispatchEvents.GuildMemberRemove: {
+      const guild = shard.client.guilds.get(data.d.guild_id);
+
+      if (!guild) {
+        shard.warn(
+          `received member remove for ${data.d.guild_id} but guild doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      guild.members.remove(data.d.user.id);
+
+      manager.event('guildMemberRemove', data.d.user.id);
+      break;
+    }
+
+    case GatewayDispatchEvents.GuildMembersChunk: {
+      const guild = shard.client.guilds.get(data.d.guild_id);
+
+      if (!guild) {
+        shard.warn(
+          `received member chunk for ${data.d.guild_id} but guild doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      for (const member of data.d.members) {
+        const memberInstance = new GuildMember(
+          shard.client,
+          guild.id,
+        )._deserialise(member);
+
+        guild.members.add(memberInstance);
+      }
+
+      manager.event(
+        'guildMembersChunk',
+        guild,
+        data.d.members.map(v => v.user!.id),
+      );
+      break;
+    }
+    //#endregion
+
+    //#region Messages
+    case GatewayDispatchEvents.MessageCreate: {
+      const channel = shard.client.channels.get(data.d.channel_id);
+
+      if (!channel) {
+        shard.warn(
+          `received message create for ${data.d.channel_id} but channel doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      if (!channel.isTextBased()) {
+        shard.warn(
+          `received message create for ${data.d.channel_id} but channel is not a text channel; ignoring`,
+        );
+        break;
+      }
+
+      const message = new Message(shard.client, data.d);
+
+      channel.messages.add(message);
+
+      manager.event('messageCreate', message);
+      break;
+    }
+    case GatewayDispatchEvents.MessageUpdate: {
+      const channel = shard.client.channels.get(data.d.channel_id);
+
+      if (!channel) {
+        shard.warn(
+          `received message update for ${data.d.channel_id} but channel doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      if (!channel.isTextBased()) {
+        shard.warn(
+          `received message update for ${data.d.channel_id} but channel is not a text channel; ignoring`,
+        );
+        break;
+      }
+
+      const message = channel.messages.get(data.d.id);
+      const oldMessage = channel.messages.get(data.d.id);
+
+      if (!message) {
+        shard.warn(
+          `received message update for ${data.d.id} but message doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      message._deserialise(data.d as APIMessage);
+
+      channel.messages.update(message);
+
+      manager.event('messageUpdate', oldMessage, message);
+      break;
+    }
+    case GatewayDispatchEvents.MessageDelete: {
+      const channel = shard.client.channels.get(data.d.channel_id);
+
+      if (!channel) {
+        shard.warn(
+          `received message delete for ${data.d.channel_id} but channel doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      if (!channel.isTextBased()) {
+        shard.warn(
+          `received message delete for ${data.d.channel_id} but channel is not a text channel; ignoring`,
+        );
+        break;
+      }
+
+      const message = channel.messages.get(data.d.id);
+
+      if (!message) {
+        shard.warn(
+          `received message delete for ${data.d.id} but message doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      channel.messages.remove(message.id);
+
+      manager.event('messageDelete', message);
       break;
     }
 

--- a/src/ws/DispatchHandler.ts
+++ b/src/ws/DispatchHandler.ts
@@ -25,7 +25,7 @@ export function handleDispatch(
       shard.session = data.d.session_id;
       shard._awaitedGuilds = data.d.guilds.map(g => g.id);
 
-      const user = new ExtendedUser(shard.client, data.d.user);
+      const user = new ExtendedUser(shard.client)._deserialise(data.d.user);
 
       shard.client.user = user;
       shard.client.users.add(user);
@@ -289,7 +289,7 @@ export function handleDispatch(
         break;
       }
 
-      const message = new Message(shard.client, data.d);
+      const message = new Message(shard.client)._deserialise(data.d);
 
       channel.messages.add(message);
 

--- a/src/ws/DispatchHandler.ts
+++ b/src/ws/DispatchHandler.ts
@@ -14,7 +14,7 @@ import { Intents } from '../util/bitfields/Intents';
 import { GatewayManager } from './GatewayManager';
 import { GatewayShard } from './GatewayShard';
 
-export function handleDispatch(
+export async function handleDispatch(
   manager: GatewayManager,
   data: GatewayDispatchPayload,
   shard: GatewayShard,
@@ -60,10 +60,14 @@ export function handleDispatch(
 
     //#region Guilds
     case GatewayDispatchEvents.GuildCreate: {
+      if (shard._awaitedGuilds === null) {
+        await shard.awaitPacket(d => d.t === 'READY');
+      }
+
       const guild = new Guild(shard.client)._deserialise(data.d);
       shard.client.guilds.add(guild);
 
-      if (shard._awaitedGuilds?.includes(guild.id)) {
+      if (shard._awaitedGuilds.includes(guild.id)) {
         shard._awaitedGuilds.splice(shard._awaitedGuilds.indexOf(guild.id), 1);
         if (shard._awaitedGuilds.length === 0) {
           shard.debug(`shard ${shard.id} has no guilds left to sync`);

--- a/src/ws/DispatchHandler.ts
+++ b/src/ws/DispatchHandler.ts
@@ -1,0 +1,93 @@
+import {
+  GatewayDispatchEvents,
+  GatewayDispatchPayload,
+} from 'discord-api-types/v10';
+import { ExtendedUser } from '../structures/ExtendedUser';
+import { Guild } from '../structures/Guild';
+import { Intents } from '../util/bitfields/Intents';
+import { GatewayManager } from './GatewayManager';
+import { GatewayShard, ShardState } from './GatewayShard';
+
+export function handleDispatch(
+  manager: GatewayManager,
+  data: GatewayDispatchPayload,
+  shard: GatewayShard,
+) {
+  switch (data.t) {
+    case GatewayDispatchEvents.Ready: {
+      shard.session = data.d.session_id;
+      shard._awaitedGuilds = data.d.guilds.map(g => g.id);
+
+      const user = new ExtendedUser(shard.client, data.d.user);
+
+      shard.client.user = user;
+      shard.client.users.add(user);
+
+      // data.d.application
+
+      shard.debug(`ready with ${data.d.guilds.length} guilds to sync`);
+
+      if ((shard.client.options.intents as Intents).has(Intents.Bits.Guilds)) {
+        shard.setTimeout(() => {
+          if (shard._awaitedGuilds.length) {
+            shard.debug(
+              `shard ${shard.id} has ${shard._awaitedGuilds.length} guilds left to sync after 20s`,
+            );
+            shard.ready();
+          }
+        }, 20e3);
+      } else {
+        shard.debug(
+          `shard ${shard.id} has no guilds to receive, marking as available`,
+        );
+        shard.ready();
+      }
+
+      break;
+    }
+    case GatewayDispatchEvents.Resumed: {
+      shard.ready();
+      break;
+    }
+    case GatewayDispatchEvents.GuildCreate: {
+      const guild = new Guild(shard.client)._deserialise(data.d);
+      shard.client.guilds.add(guild);
+
+      if (shard._awaitedGuilds?.includes(guild.id)) {
+        shard._awaitedGuilds.splice(shard._awaitedGuilds.indexOf(guild.id), 1);
+        if (shard._awaitedGuilds.length === 0) {
+          shard.debug(`shard ${shard.id} has no guilds left to sync`);
+          shard.ready();
+        }
+      } else {
+        manager.event('guildCreate', guild);
+      }
+
+      break;
+    }
+    case GatewayDispatchEvents.GuildUpdate: {
+      const guild = shard.client.guilds.get(data.d.id);
+
+      if (!guild) {
+        shard.warn(
+          `received guild update for ${data.d.id} but it doesn't exist in cache; ignoring`,
+        );
+        break;
+      }
+
+      guild._deserialise(data.d);
+
+      shard.client.guilds.update(guild);
+      break;
+    }
+    case GatewayDispatchEvents.GuildDelete: {
+      shard.client.guilds.delete(data.d.id);
+      break;
+    }
+
+    default: {
+      shard.warn(`unhandled dispatch event ${data.t}`);
+      shard.trace(data.t, data.d);
+    }
+  }
+}

--- a/src/ws/GatewayManager.ts
+++ b/src/ws/GatewayManager.ts
@@ -340,13 +340,9 @@ export class GatewayManager extends EventEmitter {
       .on('ready', () => {
         this.event('shardReady', shard);
         if (
-          [...this.shards.values()].every(
-            s => s.state === ShardState.Available,
-          ) &&
-          !this.client._ready
+          [...this.shards.values()].every(s => s.state === ShardState.Available)
         ) {
           this.event('ready');
-          this.client._ready = true;
         }
       })
       .on('resume', () => {

--- a/src/ws/GatewayShard.ts
+++ b/src/ws/GatewayShard.ts
@@ -1,36 +1,15 @@
 import { AsyncQueue } from '@sapphire/async-queue';
 import {
-  APIGuildMember,
-  APIMessage,
   Snowflake,
-  GatewayDispatchEvents,
-  GatewayDispatchPayload,
-  GatewayGuildCreateDispatchData,
-  GatewayGuildDeleteDispatchData,
-  GatewayGuildMemberAddDispatchData,
-  GatewayGuildMemberRemoveDispatchData,
-  GatewayGuildMembersChunkDispatchData,
-  GatewayGuildMemberUpdateDispatchData,
-  GatewayGuildUpdateDispatchData,
   GatewayIdentify,
-  GatewayMessageCreateDispatchData,
-  GatewayMessageDeleteBulkDispatchData,
-  GatewayMessageDeleteDispatchData,
-  GatewayMessageUpdateDispatchData,
   GatewayOpcodes,
-  GatewayReadyDispatchData,
   GatewayReceivePayload,
   GatewayResume,
   GatewaySendPayload,
 } from 'discord-api-types/v10';
 import WebSocket from 'ws';
 import { Client } from '../client/Client';
-import { Guild } from '../structures/Guild';
-import { ExtendedUser } from '../structures/ExtendedUser';
 import { Intents } from '../util/bitfields/Intents';
-import { GuildMember } from '../structures/GuildMember';
-import { Message } from '../structures/Message';
-import { TextChannel } from '../structures/templates/BaseTextChannel';
 import EventEmitter from 'node:events';
 
 /**
@@ -46,6 +25,17 @@ try {
   erlpack = require('erlpack');
 } catch {
   // it's not installed
+}
+
+export enum ShardState {
+  Disconnected = 0,
+  Connecting,
+  Reconnecting,
+  Identifying,
+  Ready,
+  Resuming,
+  GuildsReady,
+  Available,
 }
 
 /**
@@ -77,8 +67,8 @@ export class GatewayShard extends EventEmitter {
   /** The current session ID of the shard. */
   public session?: string;
 
-  /** @internal */
-  private _awaitedGuilds: Snowflake[] = [];
+  /** @internal @ignore */
+  _awaitedGuilds: Snowflake[] = [];
 
   /** @internal */
   #timers: NodeJS.Timer[] = [];
@@ -89,6 +79,8 @@ export class GatewayShard extends EventEmitter {
   get readyState() {
     return this._socket?.readyState ?? WebSocket.CONNECTING;
   }
+
+  public state = ShardState.Disconnected;
 
   constructor(public client: Client, public readonly shard: [number, number]) {
     super();
@@ -120,6 +112,7 @@ export class GatewayShard extends EventEmitter {
         session: this.session,
         seq: this.s,
       });
+      this.state = ShardState.Resuming;
       this.send(<GatewayResume>{
         op: GatewayOpcodes.Resume,
         d: {
@@ -134,6 +127,7 @@ export class GatewayShard extends EventEmitter {
         shard: this.shard.join(', '),
         intents: this.client.options.intents,
       });
+      this.state = ShardState.Identifying;
       this.send(<GatewayIdentify>{
         op: GatewayOpcodes.Identify,
         d: {
@@ -155,6 +149,8 @@ export class GatewayShard extends EventEmitter {
   public connect(url = this.url) {
     this.url = url;
 
+    this.state = ShardState.Connecting;
+
     Object.defineProperty(this, '_socket', {
       enumerable: false,
       value: new WebSocket(url),
@@ -167,6 +163,7 @@ export class GatewayShard extends EventEmitter {
     this._socket.on('message', this.onMessage.bind(this));
     this._socket.on('close', (code, reason) => {
       this.emit('close', code, reason);
+      this.state = ShardState.Disconnected;
     });
 
     return new Promise((res, rej) => {
@@ -199,23 +196,24 @@ export class GatewayShard extends EventEmitter {
     this.debug('Reset shard');
   }
 
-  /** @internal */
-  public debug(...data: any[]) {
-    this.client.debug(
-      `[${this.client.logger.kleur().blue('WS')} => ${this.client.logger
-        .kleur()
-        .yellow(this.id.toString())}]`,
-      ...data,
-    );
+  #__log_header() {
+    return `[${this.client.logger.kleur().blue('WS')} => ${this.client.logger
+      .kleur()
+      .yellow(this.id.toString())}]`;
   }
 
-  /** @internal */
-  private trace(...data: any[]) {
+  /** @internal @ignore */
+  debug(...data: any[]) {
+    this.client.debug(this.#__log_header(), ...data);
+  }
+
+  /** @internal @ignore */
+  trace(...data: any[]) {
     this.client.logger.trace(`[WS => ${this.id}]`, ...data);
   }
 
-  /** @internal */
-  private debugPretty(message: string, data: Record<string, any>) {
+  /** @internal @ignore */
+  debugPretty(message: string, data: Record<string, any>) {
     this.debug(
       message,
       '\n',
@@ -223,6 +221,16 @@ export class GatewayShard extends EventEmitter {
         .map(([K, V]) => `\t${K}\t\t:\t${V}`)
         .join('\n'),
     );
+  }
+
+  /** @internal @ignore */
+  warn(...data: any[]) {
+    this.client.logger.warn(this.#__log_header(), ...data);
+  }
+
+  /** @internal @ignore */
+  error(...data: any[]) {
+    this.client.logger.error(this.#__log_header(), ...data);
   }
 
   /** Await a packet of a specific type from the gateway. */
@@ -252,7 +260,6 @@ export class GatewayShard extends EventEmitter {
       : JSON.parse(buffer.toString());
 
     this.emit('packet', data);
-    this.trace('packet received:', data);
 
     const payload: any = data.d;
 
@@ -285,6 +292,8 @@ export class GatewayShard extends EventEmitter {
         break;
       }
       case GatewayOpcodes.Reconnect: {
+        this.trace('received reconnect opcode');
+
         this.reconnect();
 
         break;
@@ -297,249 +306,23 @@ export class GatewayShard extends EventEmitter {
         break;
       }
       case GatewayOpcodes.Dispatch: {
-        let event = payload as GatewayDispatchPayload['d'];
-
         this.trace('received dispatch', data.t);
 
         this.emit(data.t, data.d);
-
-        switch (data.t) {
-          case GatewayDispatchEvents.Ready: {
-            event = event as GatewayReadyDispatchData;
-
-            this.session = event.session_id;
-            this._awaitedGuilds = event.guilds.map(v => v.id as Snowflake);
-
-            this.debugPretty('ready!', {
-              session: this.session,
-              guilds: event.guilds?.length,
-            });
-
-            this.client.users.add(
-              new ExtendedUser(this.client)._deserialise(event.user),
-            );
-
-            this.client.user = this.client.users.get(
-              event.user.id as Snowflake,
-            ) as ExtendedUser;
-
-            if (
-              !(<Intents>this.client.options.intents).has(Intents.Bits.Guilds)
-            ) {
-              this.client.logger.warn(
-                "Client intents don't include guilds, this may cause issues.",
-              );
-              this.client.delegate('meta.ready');
-            }
-
-            break;
-          }
-          case GatewayDispatchEvents.Resumed: {
-            this.debug('resumed session', this.session);
-            this.client.delegate('meta.resumed', this.session);
-            break;
-          }
-          case GatewayDispatchEvents.GuildCreate: {
-            const data = event as GatewayGuildCreateDispatchData;
-            this.client.guilds.add(new Guild(this.client)._deserialise(data));
-
-            if (this._awaitedGuilds.includes(data.id as Snowflake)) {
-              this._awaitedGuilds = this._awaitedGuilds.filter(
-                v => v !== data.id,
-              );
-
-              if (this._awaitedGuilds.length === 0) {
-                this.client.delegate('meta.ready');
-              }
-            } else {
-              this.client.delegate(
-                'guilds.create',
-                this.client.guilds.cache.get(data.id as Snowflake),
-              );
-            }
-            break;
-          }
-          case GatewayDispatchEvents.GuildUpdate: {
-            const data = event as GatewayGuildUpdateDispatchData;
-            const guild = this.client.guilds.cache.get(data.id as Snowflake);
-            const newGuild =
-              guild?._deserialise(data) ??
-              new Guild(this.client)._deserialise(data);
-
-            this.client.guilds.update(newGuild);
-
-            this.client.delegate('guilds.update', guild, newGuild);
-            break;
-          }
-          case GatewayDispatchEvents.GuildDelete: {
-            const data = event as GatewayGuildDeleteDispatchData;
-            this.client.guilds.remove(data.id as Snowflake);
-
-            this.client.delegate('guilds.delete', data.id);
-            break;
-          }
-          case GatewayDispatchEvents.GuildMemberAdd: {
-            const data = event as GatewayGuildMemberAddDispatchData;
-            const guild = this.client.guilds.cache.get(
-              data.guild_id as Snowflake,
-            );
-
-            if (guild) {
-              const member = new GuildMember(
-                this.client,
-                guild.id,
-              )._deserialise(data);
-              guild.members.add(member);
-
-              this.client.delegate('guilds.members.add', member);
-            }
-            break;
-          }
-          case GatewayDispatchEvents.GuildMemberRemove: {
-            const data = event as GatewayGuildMemberRemoveDispatchData;
-            const guild = this.client.guilds.cache.get(
-              data.guild_id as Snowflake,
-            );
-
-            if (guild) {
-              const member = guild.members.get(
-                data.user.id as Snowflake,
-              ) as GuildMember;
-
-              guild.members.remove(member.id);
-
-              this.client.delegate(
-                'guilds.members.remove',
-                member.user!,
-                guild,
-              );
-              this.client.guilds.update(guild!);
-            }
-
-            break;
-          }
-          case GatewayDispatchEvents.GuildMemberUpdate: {
-            const data = event as GatewayGuildMemberUpdateDispatchData;
-            const guild = this.client.guilds.cache.get(
-              data.guild_id as Snowflake,
-            );
-
-            if (guild) {
-              const member =
-                guild.members.get(data.user.id as Snowflake) ??
-                (await guild.members.fetch(data.user.id as Snowflake));
-
-              const newMember = member._deserialise(data as APIGuildMember);
-
-              guild.members.update(newMember);
-
-              this.client.delegate('guilds.members.update', member, newMember);
-              this.client.guilds.update(guild!);
-            }
-            break;
-          }
-          case GatewayDispatchEvents.GuildMembersChunk: {
-            const data = event as GatewayGuildMembersChunkDispatchData;
-            const guild = this.client.guilds.cache.get(
-              data.guild_id as Snowflake,
-            );
-
-            if (guild) {
-              const members = data.members.map(v =>
-                new GuildMember(this.client, guild.id)._deserialise(v),
-              );
-
-              guild.members.addMany(members);
-
-              this.client.delegate('guilds.members.chunk', members);
-              this.client.guilds.update(guild!);
-            }
-            break;
-          }
-          case GatewayDispatchEvents.MessageCreate: {
-            const data = event as GatewayMessageCreateDispatchData;
-            const channel = this.client.channels.cache.get(
-              data.channel_id as Snowflake,
-            ) as TextChannel;
-
-            if (channel) {
-              const message = new Message<typeof channel>(
-                this.client,
-              )._deserialise(data);
-
-              channel.messages.add(message);
-
-              this.client.delegate('meta.messages.create', message);
-            }
-            break;
-          }
-          case GatewayDispatchEvents.MessageUpdate: {
-            const data = event as GatewayMessageUpdateDispatchData;
-            const channel = this.client.channels.cache.get(
-              data.channel_id as Snowflake,
-            ) as TextChannel;
-
-            if (channel) {
-              const message = channel.messages.cache.get(
-                data.id as Snowflake,
-              ) as Message<typeof channel>;
-
-              if (message) {
-                const newMessage = message._deserialise(data as APIMessage);
-                channel.messages.update(newMessage);
-
-                this.client.delegate(
-                  'meta.messages.update',
-                  message,
-                  newMessage,
-                );
-              }
-            }
-            break;
-          }
-          case GatewayDispatchEvents.MessageDelete: {
-            const data = event as GatewayMessageDeleteDispatchData;
-            const channel = this.client.channels.cache.get(
-              data.channel_id as Snowflake,
-            ) as TextChannel;
-
-            if (channel) {
-              channel.messages.cache.delete(data.id as Snowflake);
-
-              this.client.delegate('meta.messages.delete', {
-                channel,
-                guild: channel.guild,
-                id: data.id,
-              });
-            }
-            break;
-          }
-          case GatewayDispatchEvents.MessageDeleteBulk: {
-            const data = event as GatewayMessageDeleteBulkDispatchData;
-            const channel = this.client.channels.cache.get(
-              data.channel_id as Snowflake,
-            ) as TextChannel;
-
-            if (channel) {
-              channel.messages.removeMany(data.ids as Snowflake[]);
-
-              this.client.delegate('meta.messages.delete', {
-                channel,
-                guild: channel.guild,
-                ids: data.ids,
-              });
-            }
-            break;
-          }
-          default: {
-            this.client.logger.warn('Unhandled dispatch event', data.t);
-            this.trace('Event:', data.d);
-          }
-        }
+        this.emit('dispatch', data);
 
         break;
       }
     }
+  }
+
+  ready() {
+    if (this.state === ShardState.Available || this._awaitedGuilds.length) {
+      return true;
+    }
+
+    this.state = ShardState.Available;
+    this.emit('ready');
   }
 
   /**
@@ -635,8 +418,12 @@ export class GatewayShard extends EventEmitter {
 
   /** Reconnect to the gateway. */
   public reconnect() {
+    this.emit('reconnect');
+
     this.close(true);
     this.connect(this.url);
+
+    this.state = ShardState.Reconnecting;
   }
 
   /** @internal */
@@ -650,5 +437,10 @@ export class GatewayShard extends EventEmitter {
         this.heartbeat_interval * Math.random(),
       ),
     );
+  }
+
+  /** @internal @ignore */
+  setTimeout(func: (...args: any[]) => any, timeout: number) {
+    return this.#timeouts.push(setTimeout(func, timeout));
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,27 @@
 #!/bin/node
-/** @format */
 
 const { DefaultClientOptions, Intents } = require('..');
 const Fuwa = require('..');
+
+{
+  // reading token from file
+  if (
+    !process.env.DISCORD_TOKEN?.length ||
+    process.env.DISCORD_TOKEN.startsWith('::readfrom::')
+  ) {
+    const token = require('fs')
+      .readFileSync(
+        process.env.DISCORD_TOKEN.replace(/^::readfrom::/, '').replace(
+          /~~/g,
+          process.cwd(),
+        ),
+        'utf8',
+      )
+      .trim();
+
+    process.env.DISCORD_TOKEN = token;
+  }
+}
 
 const client = new Fuwa.Client(process.env.DISCORD_TOKEN, {
   logger: {
@@ -17,6 +36,10 @@ const trends = new Map();
 
 client.on('messageCreate', async m => {
   if (m.author.bot) return;
+
+  console.log(
+    `${m.author.username}#${m.author.discriminator} (${m.author.tag}): ${m.content}`,
+  );
 
   client.logger.trace(
     `${m.author.username}#${m.author.discriminator}: ${m.content}`,

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ const client = new Fuwa.Client(process.env.DISCORD_TOKEN, {
 
 const trends = new Map();
 
-client.on('messages.create', async m => {
+client.on('messageCreate', async m => {
   if (m.author.bot) return;
 
   client.logger.trace(

--- a/typings/client/Client.d.ts
+++ b/typings/client/Client.d.ts
@@ -27,7 +27,6 @@ export declare class Client extends EventEmitter {
     user: ExtendedUser | null;
     private timeouts;
     private timers;
-    _ready: boolean;
     constructor(token: string, options?: ClientOptions);
     connect(): Promise<void>;
     token(redact?: boolean): string;

--- a/typings/client/Client.d.ts
+++ b/typings/client/Client.d.ts
@@ -27,6 +27,7 @@ export declare class Client extends EventEmitter {
     user: ExtendedUser | null;
     private timeouts;
     private timers;
+    _ready: boolean;
     constructor(token: string, options?: ClientOptions);
     connect(): Promise<void>;
     token(redact?: boolean): string;

--- a/typings/structures/Channel.d.ts
+++ b/typings/structures/Channel.d.ts
@@ -2,8 +2,11 @@ import { APIChannel, APIChannelBase, ChannelType, Snowflake } from 'discord-api-
 import { Client } from '../client/Client.js';
 import type { DMChannel } from './DMChannel.js';
 import { Guild } from './Guild';
-import { GuildChannels } from './GuildChannel.js';
+import { GuildChannel, GuildChannels } from './GuildChannel.js';
+import { GuildTextChannel } from './GuildTextChannel.js';
+import { GuildVoiceChannel } from './GuildVoiceChannel.js';
 import { BaseStructure } from './templates/BaseStructure';
+import { TextChannel } from './templates/BaseTextChannel.js';
 export declare class Channel<T extends APIChannel = APIChannel> extends BaseStructure<T> {
     type: ChannelType;
     guildId: Snowflake | null;
@@ -18,6 +21,13 @@ export declare class Channel<T extends APIChannel = APIChannel> extends BaseStru
     edit(data: any): Promise<this>;
     fetch(): Promise<this>;
     toJSON(): T;
+    isDM(): this is DMChannel;
+    isGuild(): this is GuildChannels;
+    isText(): this is GuildTextChannel;
+    isVoice(): this is GuildVoiceChannel;
+    isCategory(): this is GuildChannel;
+    isTextBased(): this is TextChannel;
+    isVoiceBased(): this is GuildVoiceChannel;
 }
 export declare type Channels<T = GuildChannels | Channel | DMChannel, D = APIChannel> = T & {
     id: Snowflake;

--- a/typings/structures/GuildMember.d.ts
+++ b/typings/structures/GuildMember.d.ts
@@ -28,7 +28,7 @@ export declare class GuildMember extends BaseStructure<APIGuildMember> {
     mute: boolean;
     constructor(client: Client, guildId: Snowflake);
     _deserialise(data: APIGuildMember & {
-        joined_at: string | null;
+        joined_at?: string | null;
     }): this;
     _patch(data: APIGuildMember, guild?: Guild, user?: User): this;
     fetch(): Promise<GuildMember>;

--- a/typings/structures/templates/BaseTextChannel.d.ts
+++ b/typings/structures/templates/BaseTextChannel.d.ts
@@ -5,6 +5,7 @@ import { Channel } from '../Channel.js';
 import { DMChannel } from '../DMChannel';
 import { GuildChannel } from '../GuildChannel';
 import { GuildTextChannel } from '../GuildTextChannel';
+import { GuildVoiceChannel } from '../GuildVoiceChannel.js';
 import { ChannelMessageManager } from '../managers/ChannelMessageManager';
 export interface BaseTextChannel extends Channel {
     lastMessageId: Snowflake | null;
@@ -20,4 +21,4 @@ export declare class BaseTextChannelInGuild extends GuildChannel implements Base
     get createMessage(): (data: string | MessagePayload | MessagePayloadData, cache?: boolean) => Promise<import("../Message").Message<TextChannel>>;
 }
 export declare const BaseTextChannel: new (client: Client) => BaseTextChannel;
-export declare type TextChannel = DMChannel | GuildTextChannel;
+export declare type TextChannel = DMChannel | GuildTextChannel | GuildVoiceChannel;

--- a/typings/ws/DispatchHandler.d.ts
+++ b/typings/ws/DispatchHandler.d.ts
@@ -1,4 +1,4 @@
 import { GatewayDispatchPayload } from 'discord-api-types/v10';
 import { GatewayManager } from './GatewayManager';
 import { GatewayShard } from './GatewayShard';
-export declare function handleDispatch(manager: GatewayManager, data: GatewayDispatchPayload, shard: GatewayShard): void;
+export declare function handleDispatch(manager: GatewayManager, data: GatewayDispatchPayload, shard: GatewayShard): Promise<void>;

--- a/typings/ws/DispatchHandler.d.ts
+++ b/typings/ws/DispatchHandler.d.ts
@@ -1,4 +1,4 @@
-import { GatewayDispatchPayload } from "discord-api-types/v10";
-import { GatewayManager } from "./GatewayManager";
-import { GatewayShard } from "./GatewayShard";
+import { GatewayDispatchPayload } from 'discord-api-types/v10';
+import { GatewayManager } from './GatewayManager';
+import { GatewayShard } from './GatewayShard';
 export declare function handleDispatch(manager: GatewayManager, data: GatewayDispatchPayload, shard: GatewayShard): void;

--- a/typings/ws/DispatchHandler.d.ts
+++ b/typings/ws/DispatchHandler.d.ts
@@ -1,0 +1,4 @@
+import { GatewayDispatchPayload } from "discord-api-types/v10";
+import { GatewayManager } from "./GatewayManager";
+import { GatewayShard } from "./GatewayShard";
+export declare function handleDispatch(manager: GatewayManager, data: GatewayDispatchPayload, shard: GatewayShard): void;

--- a/typings/ws/GatewayManager.d.ts
+++ b/typings/ws/GatewayManager.d.ts
@@ -28,6 +28,7 @@ export declare class GatewayManager extends EventEmitter {
     private fetchGatewayBot;
     private constructGatewayURL;
     reset(): void;
+    event(name: string, ...data: any[]): void;
 }
 export interface GatewayManagerShardingOptions extends Omit<GatewayManagerOptions, 'shards' | 'id' | 'count'> {
     mode: 'env' | 'worker';

--- a/typings/ws/GatewayShard.d.ts
+++ b/typings/ws/GatewayShard.d.ts
@@ -1,10 +1,20 @@
 /// <reference types="node" />
-import { GatewayReceivePayload, GatewaySendPayload } from 'discord-api-types/v10';
+import { Snowflake, GatewayReceivePayload, GatewaySendPayload } from 'discord-api-types/v10';
 import { Client } from '../client/Client';
 import EventEmitter from 'node:events';
 export interface Erlpack {
     pack(data: any): Buffer;
     unpack<T>(data: Buffer): T;
+}
+export declare enum ShardState {
+    Disconnected = 0,
+    Connecting = 1,
+    Reconnecting = 2,
+    Identifying = 3,
+    Ready = 4,
+    Resuming = 5,
+    GuildsReady = 6,
+    Available = 7
 }
 export declare class GatewayShard extends EventEmitter {
     #private;
@@ -22,20 +32,25 @@ export declare class GatewayShard extends EventEmitter {
     ping: number;
     private s;
     session?: string;
-    private _awaitedGuilds;
-    get readyState(): 0 | 1 | 2 | 3;
+    _awaitedGuilds: Snowflake[];
+    get readyState(): 0 | 2 | 1 | 3;
+    state: ShardState;
     constructor(client: Client, shard: [number, number]);
     private authenticate;
     connect(url?: string): Promise<unknown>;
     reset(full?: boolean): void;
     debug(...data: any[]): void;
-    private trace;
-    private debugPretty;
+    trace(...data: any[]): void;
+    debugPretty(message: string, data: Record<string, any>): void;
+    warn(...data: any[]): void;
+    error(...data: any[]): void;
     awaitPacket(filter: (payload: GatewayReceivePayload) => boolean): Promise<unknown>;
     private onMessage;
+    ready(): true | undefined;
     send(packet: GatewaySendPayload): Promise<void>;
     heartbeat(): void;
     close(resume?: boolean): void;
     reconnect(): void;
     private startHeartbeat;
+    setTimeout(func: (...args: any[]) => any, timeout: number): number;
 }

--- a/typings/ws/GatewayShard.d.ts
+++ b/typings/ws/GatewayShard.d.ts
@@ -33,7 +33,7 @@ export declare class GatewayShard extends EventEmitter {
     private s;
     session?: string;
     _awaitedGuilds: Snowflake[];
-    get readyState(): 0 | 2 | 1 | 3;
+    get readyState(): 0 | 1 | 2 | 3;
     state: ShardState;
     constructor(client: Client, shard: [number, number]);
     private authenticate;

--- a/typings/ws/GatewayShard.d.ts
+++ b/typings/ws/GatewayShard.d.ts
@@ -30,7 +30,7 @@ export declare class GatewayShard extends EventEmitter {
     private heartbeat_acked;
     url: string;
     ping: number;
-    private s;
+    seq: number;
     session?: string;
     _awaitedGuilds: Snowflake[];
     get readyState(): 0 | 1 | 2 | 3;

--- a/typings/ws/GatewayShard.d.ts
+++ b/typings/ws/GatewayShard.d.ts
@@ -33,7 +33,7 @@ export declare class GatewayShard extends EventEmitter {
     seq: number;
     session?: string;
     _awaitedGuilds: Snowflake[];
-    get readyState(): 0 | 1 | 2 | 3;
+    get readyState(): 0 | 2 | 1 | 3;
     state: ShardState;
     constructor(client: Client, shard: [number, number]);
     private authenticate;


### PR DESCRIPTION
BREAKING CHANGE: all `x.y(.z)` events have been renamed to their camelCase and singular scope variants, i.e. `messages.create` has been renamed to `messageCreate`

